### PR TITLE
Roundabout and Double Cross page breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ To generate the cue sheet sub-website, install mkdocs and run it.
 
 The mkdocs-pdf-export-plugin contains all dependencies needed except for Cairo...
 You'll need to read the docs to install GTK for that. See the Weasyprint instructions.
-Possibly run gtk2r-env.bat
+Possibly run gtk2r-env.bat 
+Possibly set WEASYPRINT_DLL_DIRECTORIES=C:\Program Files\Inkscape\bin 
+Or whatever directory containts libgobject-2.0-0.dll
+
+
 
 
 To build the cue-sheet part of the website

--- a/cue-sheets/doublecross-north.md
+++ b/cue-sheets/doublecross-north.md
@@ -38,6 +38,9 @@ This section includes Ft. Funston, Lake Merced hike/bike path, Harding Park golf
 * Proceed downhill on Wawona to 14th Ave. and turn right.
 * Turn left on West Portal Ave. and walk to West Portal Station.
 
+
+<div style="page-break-after: always;"></div>
+
 ## Section 2 - West Portal Station to Duboce Park 
 
 *Transit* K, M or S Light Rail Lines or bus 48 or 57 to West Portal Muni Station.
@@ -88,6 +91,8 @@ This section passes through Edgehill Open Space, Twin Peaks, Tank Hill, Mt. Olym
 * Cross and walk left down Buena Vista East until Adah’s Stairway on right, opposite the decommissioned red fire alarm. Descend stairs and continue on Waller.  
 * Cross Divisadero/Castro at either crosswalk and continue down to Scott. Turn right on Scott and left on Duboce to arrive at N Judah Light Rail stop adjacent to Duboce Park entrance. (**Restrooms** in Harvey Milk Rec Center, closed Sunday and Monday).
 
+
+<div style="page-break-after: always;"></div>
 
 ## Section 3 - Duboce Park to The Embarcadero 
 

--- a/cue-sheets/doublecross-south.md
+++ b/cue-sheets/doublecross-south.md
@@ -45,6 +45,7 @@ This section includes Telegraph Hill, North Beach, Chinatown, Nob Hill, Civic Ce
 * Walk across Hayes and follow Pierce to Duboce Park entrance
 * Follow path that leads to playground, and exit park at N Judah Light Rail Stop at Duboce and Noe. (**Restrooms** in Harvey Milk Rec Center, closed Sunday and Monday.  
 
+<div style="page-break-after: always;"></div>
 
 ## Section 2 - Duboce Park to West Portal Station
 
@@ -98,6 +99,7 @@ This section includes Buena Vista Park, Mt. Olympus, Tank Hill, Twin Peaks, and 
 * Left on Ulloa to West Portal Station (**Note**: Access to K, M, and S Light Rail lines)
 
 
+<div style="page-break-after: always;"></div>
  
 ## Section 1 - West Portal Station to Fort Funston
 

--- a/cue-sheets/roundabout-clockwise.md
+++ b/cue-sheets/roundabout-clockwise.md
@@ -22,6 +22,8 @@
 * Section 1 ends at Heron's Head Park (**Restrooms**).
 
 
+<div style="page-break-after: always;"></div>
+
 ## Roundabout Section 2 Clockwise: Heron’s Head Park to Visitacion Valley Greenway
 *Trailhead*: Heron’s Head Park, 32 Jennings  
 *Transit*: Muni 44 O’Shaughnessy and 19 Polk stop one block away at Evans and Middle Point.  
@@ -65,6 +67,7 @@
 * Section 2 ends at bottom of Visitaction Valley Greenway at Leland and Peabody.
 
 
+<div style="page-break-after: always;"></div>
 
 ## Roundabout Section 3 Clockwise: Visitacion Valley Greenway to Daly City BART 
 *Trailhead*: Visitacion Valley Greenway, next to Mission Blue, 144 Leland  
@@ -97,6 +100,7 @@
 * Walk right at stop sign to finish Section 3 at Daly City BART.
 
 
+<div style="page-break-after: always;"></div>
 
 
 ## Roundabout Section 4 Clockwise: Daly City BART to Lands' End 
@@ -127,6 +131,8 @@
 * Cross Point Lobos Ave and walk left to finish Section 4 at Lands End Lookout Visitors Center (**Restrooms**).
 
 
+<div style="page-break-after: always;"></div>
+
 ## Roundabout Section 5 Clockwise: Lands End to Tunnel Tops
 *Trailhead*: Lands End Lookout Visitors Center  
 *Transit*: Muni 38 and 38R Geary stop on 48th Ave, a block away.  
@@ -147,6 +153,7 @@
 * Proceed to Presidio Transit Center (**restrooms**, cafe) to finish Section 5. 
 
 
+<div style="page-break-after: always;"></div>
 
 ## Roundabout Section 6 Clockwise: Tunnel Tops to Ferry Building
 *Trailhead*: Presidio Transit Center  


### PR DESCRIPTION
Add page breaks for printing Roundabout and Double Cross cue sheets.
Also tweak readme to make it easier to run mkdocs.
